### PR TITLE
Add link to Android About Box library

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Apps using this library
 * [Monitor for EnergyHive & Engage][5]
 * [Crafting Assistant NMS](https://play.google.com/store/apps/details?id=biemann.android.craftingnms)
 * [ComicsDB Client](https://play.google.com/store/apps/details?id=cz.kutner.comicsdbclient.comicsdbclient), code available on [GitHub](https://github.com/tukak/comicsdbclient)
+* [Android About Box](https://github.com/eggheadgames/android-about-box) (library) - an opinionated About Box for Android
 
 License
 -------


### PR DESCRIPTION
Wasn't sure if you'd prefer a new heading ("LIbraries Using ...") or just add this under the existing apps heading. Happy to modify.

Great library! We used it to create another library that adds common features like links to all apps published by the developer, a link to send email, etc.