### PR TITLE
Add a description for title items

### DIFF
--- a/library/src/main/java/com/danielstone/materialaboutlibrary/ConvenienceBuilder.java
+++ b/library/src/main/java/com/danielstone/materialaboutlibrary/ConvenienceBuilder.java
@@ -25,7 +25,7 @@ import com.danielstone.materialaboutlibrary.util.OpenSourceLicense;
 public class ConvenienceBuilder {
 
     public static MaterialAboutTitleItem createAppTitleItem(String appName, Drawable applicationIcon) {
-        return new MaterialAboutTitleItem(appName, applicationIcon);
+        return new MaterialAboutTitleItem(appName, null, applicationIcon);
     }
 
     public static MaterialAboutTitleItem createAppTitleItem(Context c) {

--- a/library/src/main/java/com/danielstone/materialaboutlibrary/items/MaterialAboutTitleItem.java
+++ b/library/src/main/java/com/danielstone/materialaboutlibrary/items/MaterialAboutTitleItem.java
@@ -21,6 +21,8 @@ public class MaterialAboutTitleItem extends MaterialAboutItem {
 
     private CharSequence text = null;
     private int textRes = 0;
+    private CharSequence desc = null;
+    private int descRes = 0;
     private Drawable icon = null;
     private int iconRes = 0;
     private MaterialAboutItemOnClickListener onClickListener = null;
@@ -29,19 +31,24 @@ public class MaterialAboutTitleItem extends MaterialAboutItem {
         this.text = builder.text;
         this.textRes = builder.textRes;
 
+        this.desc = builder.desc;
+        this.descRes = builder.descRes;
+
         this.icon = builder.icon;
         this.iconRes = builder.iconRes;
 
         this.onClickListener = builder.onClickListener;
     }
 
-    public MaterialAboutTitleItem(CharSequence text, Drawable icon) {
+    public MaterialAboutTitleItem(CharSequence text, CharSequence desc, Drawable icon) {
         this.text = text;
+        this.desc = desc;
         this.icon = icon;
     }
 
-    public MaterialAboutTitleItem(int textRes, int iconRes) {
+    public MaterialAboutTitleItem(int textRes, int descRes, int iconRes) {
         this.textRes = textRes;
+        this.descRes = descRes;
         this.iconRes = iconRes;
     }
 
@@ -61,6 +68,18 @@ public class MaterialAboutTitleItem extends MaterialAboutItem {
             holder.text.setText(textRes);
         } else {
             holder.text.setVisibility(GONE);
+        }
+
+        CharSequence desc = item.getDesc();
+        int descRes = item.getDescRes();
+
+        holder.desc.setVisibility(View.VISIBLE);
+        if (text != null) {
+            holder.desc.setText(desc);
+        } else if (descRes != 0) {
+            holder.desc.setText(descRes);
+        } else {
+            holder.desc.setVisibility(GONE);
         }
 
         Drawable drawable = item.getIcon();
@@ -123,6 +142,26 @@ public class MaterialAboutTitleItem extends MaterialAboutItem {
         return this;
     }
 
+    public CharSequence getDesc() {
+        return desc;
+    }
+
+    public MaterialAboutTitleItem setDesc(CharSequence desc) {
+        this.descRes = 0;
+        this.desc = desc;
+        return this;
+    }
+
+    public int getDescRes() {
+        return descRes;
+    }
+
+    public MaterialAboutTitleItem setDescRes(int descRes) {
+        this.desc = null;
+        this.descRes = textRes;
+        return this;
+    }
+
     public Drawable getIcon() {
         return icon;
     }
@@ -156,6 +195,7 @@ public class MaterialAboutTitleItem extends MaterialAboutItem {
         public final View view;
         public final ImageView icon;
         public final TextView text;
+        public final TextView desc;
         public MaterialAboutItemOnClickListener onClickListener;
 
         MaterialAboutTitleItemViewHolder(View view) {
@@ -163,6 +203,7 @@ public class MaterialAboutTitleItem extends MaterialAboutItem {
             this.view = view;
             icon = (ImageView) view.findViewById(R.id.mal_item_image);
             text = (TextView) view.findViewById(R.id.mal_item_text);
+            desc = (TextView) view.findViewById(R.id.mal_item_desc);
 
             view.setOnClickListener(this);
             view.setOnLongClickListener(this);
@@ -192,6 +233,9 @@ public class MaterialAboutTitleItem extends MaterialAboutItem {
         private CharSequence text = null;
         @StringRes
         private int textRes = 0;
+        private CharSequence desc = null;
+        @StringRes
+        private int descRes = 0;
         private Drawable icon = null;
         @DrawableRes
         private int iconRes = 0;
@@ -206,6 +250,19 @@ public class MaterialAboutTitleItem extends MaterialAboutItem {
         public MaterialAboutTitleItem.Builder text(@StringRes int text) {
             this.textRes = text;
             this.text = null;
+            return this;
+        }
+
+        public MaterialAboutTitleItem.Builder desc(CharSequence desc) {
+            this.desc = desc;
+            this.descRes = 0;
+            return this;
+        }
+
+
+        public MaterialAboutTitleItem.Builder desc(@StringRes int desc) {
+            this.descRes = desc;
+            this.desc = null;
             return this;
         }
 

--- a/library/src/main/res/layout/mal_material_about_title_item.xml
+++ b/library/src/main/res/layout/mal_material_about_title_item.xml
@@ -5,36 +5,53 @@
     android:layout_height="wrap_content"
     android:orientation="horizontal"
     android:paddingBottom="@dimen/mal_baseline_half"
-    android:paddingTop="@dimen/mal_baseline_half"
-    android:paddingLeft="@dimen/mal_baseline_half"
-    android:paddingStart="@dimen/mal_baseline_half"
     android:paddingEnd="@dimen/mal_baseline"
-    android:paddingRight="@dimen/mal_baseline">
+    android:paddingLeft="@dimen/mal_baseline_half"
+    android:paddingRight="@dimen/mal_baseline"
+    android:paddingStart="@dimen/mal_baseline_half"
+    android:paddingTop="@dimen/mal_baseline_half">
 
     <ImageView
         android:id="@+id/mal_item_image"
         android:layout_width="@dimen/mal_title_item_image_size"
         android:layout_height="@dimen/mal_title_item_image_size"
         android:layout_gravity="center"
-        android:layout_marginLeft="@dimen/mal_baseline_half"
-        android:layout_marginStart="@dimen/mal_baseline_half"
         android:layout_marginEnd="@dimen/mal_baseline_half"
+        android:layout_marginLeft="@dimen/mal_baseline_half"
         android:layout_marginRight="@dimen/mal_baseline_half"
+        android:layout_marginStart="@dimen/mal_baseline_half"
         android:adjustViewBounds="false"
         android:contentDescription="@string/mal_content_desc_application_icon"
         android:cropToPadding="false"
         android:scaleType="fitCenter"
         app:srcCompat="@android:drawable/sym_def_app_icon" />
 
-    <TextView
-        android:id="@+id/mal_item_text"
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:layout_marginLeft="@dimen/mal_baseline_half"
-        android:layout_marginStart="@dimen/mal_baseline_half"
         android:layout_weight="1"
-        android:textAppearance="@style/TextAppearance.AppCompat.Headline"
-        android:textColor="?mal_color_primary" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/mal_item_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/mal_baseline_half"
+            android:layout_marginStart="@dimen/mal_baseline_half"
+            android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+            android:textColor="?mal_color_primary" />
+
+        <TextView
+            android:id="@+id/mal_item_desc"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="@dimen/mal_baseline_half"
+            android:layout_marginStart="@dimen/mal_baseline_half"
+            android:layout_marginTop="-4dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            android:textColor="?mal_color_secondary" />
+
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
This change would allow devs to set a description for their title items. This would be useful for example to display a motto or slogan. Devs who do not opt to use the description will not be affected by this change.