### PR TITLE
Fix issues with styles not getting applied correctly

### DIFF
--- a/library/src/main/java/com/danielstone/materialaboutlibrary/MaterialAboutFragment.java
+++ b/library/src/main/java/com/danielstone/materialaboutlibrary/MaterialAboutFragment.java
@@ -50,12 +50,6 @@ public abstract class MaterialAboutFragment extends Fragment {
         return true;
     }
 
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-    }
-
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -68,10 +62,9 @@ public abstract class MaterialAboutFragment extends Fragment {
                 style = R.style.Theme_Mal_Dark_DarkActionBar;
                 break;
         }
-        // create ContextThemeWrapper from the original Activity Context with the custom theme
-        final Context contextThemeWrapper = new android.view.ContextThemeWrapper(getActivity(), style);
-        LayoutInflater localInflater = inflater.cloneInContext(contextThemeWrapper);
-        View rootView = localInflater.inflate(R.layout.mal_material_about_fragment, container, false);
+
+        getContext().getTheme().applyStyle(style, false);
+        View rootView = inflater.inflate(R.layout.mal_material_about_fragment, container, false);
 
         recyclerView = (RecyclerView) rootView.findViewById(R.id.mal_recyclerview);
         adapter = new MaterialAboutListAdapter(list, getViewTypeManager());
@@ -123,7 +116,8 @@ public abstract class MaterialAboutFragment extends Fragment {
                         .alpha(1f)
                         .translationY(0f)
                         .setDuration(400)
-                        .setInterpolator(new FastOutSlowInInterpolator()).start();
+                        .setInterpolator(new FastOutSlowInInterpolator())
+                        .start();
             } else {
                 recyclerView.setAlpha(1f);
                 recyclerView.setTranslationY(0f);

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -2,51 +2,32 @@
 <resources>
 
     <style name="Theme.Mal" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <item name="mal_lightActionBar">false</item>
-        <item name="mal_popupOverlay">@style/Theme.Mal.Light.PopupOverlay</item>
         <item name="mal_color_primary">@color/mal_text_primary</item>
         <item name="mal_color_secondary">@color/mal_text_secondary</item>
     </style>
 
-    <style name="Theme.Mal.Light.DarkActionBar" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
+    <style name="Theme.Mal.Light.DarkActionBar" parent="Theme.Mal">
         <item name="mal_lightActionBar">false</item>
         <item name="mal_popupOverlay">@style/Theme.Mal.Light.PopupOverlay</item>
-        <item name="mal_color_primary">@color/mal_text_primary</item>
-        <item name="mal_color_secondary">@color/mal_text_secondary</item>
     </style>
 
-    <style name="Theme.Mal.Light.LightActionBar" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
+    <style name="Theme.Mal.Light.LightActionBar" parent="Theme.Mal">
         <item name="mal_lightActionBar">true</item>
         <item name="mal_popupOverlay">@style/Theme.Mal.Light.PopupOverlay</item>
-        <item name="mal_color_primary">@color/mal_text_primary</item>
-        <item name="mal_color_secondary">@color/mal_text_secondary</item>
     </style>
 
-    <style name="Theme.Mal.Dark.DarkActionBar" parent="Theme.AppCompat.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
+    <style name="Theme.Mal.Dark.DarkActionBar" parent="Theme.Mal">
         <item name="mal_lightActionBar">false</item>
         <item name="mal_popupOverlay">@style/Theme.Mal.Dark.PopupOverlay</item>
-        <item name="mal_color_primary">@color/mal_text_primary_dark</item>
-        <item name="mal_color_secondary">@color/mal_text_secondary_dark</item>
     </style>
 
-    <style name="Theme.Mal.Dark.LightActionBar" parent="Theme.AppCompat.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
+    <style name="Theme.Mal.Dark.LightActionBar" parent="Theme.Mal">
         <item name="mal_lightActionBar">true</item>
         <item name="mal_popupOverlay">@style/Theme.Mal.Dark.PopupOverlay</item>
-        <item name="mal_color_primary">@color/mal_text_primary_dark</item>
-        <item name="mal_color_secondary">@color/mal_text_secondary_dark</item>
     </style>
 
     <style name="Theme.Mal.Light.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+
     <style name="Theme.Mal.Dark.PopupOverlay" parent="ThemeOverlay.AppCompat" />
 
 </resources>


### PR DESCRIPTION
The previous approach had the problem, that styles were not picked up correctly in the `Fragment`. This was notable especially with the `colorPrimary`, which did not appear in the overscroll effect.

| Before | After |
| -- | -- |
| ![screenshot_20170425-234648](https://cloud.githubusercontent.com/assets/8021265/25409520/8cd374f6-2a12-11e7-9db4-624bbc980595.png) | ![screenshot_20170425-234010](https://cloud.githubusercontent.com/assets/8021265/25409524/91600a48-2a12-11e7-9606-717fdee317f9.png) |

#### Code changes
- `applyStyle` (with `force` = `false`) is now in use, to only merge our custom `mal` attributes in, but leave the rest of the theme as it was.
- Cleanups for the style itself, properly inherting from `Theme.Mal` theme. `windowActionBar` and `windowNoTitle` were removed, because they are already set in the parent `Theme.AppCompat.Light.NoActionBar`.