### PR TITLE
Use application context instead of context to avoid leaking memory

### DIFF
--- a/library/src/main/java/com/danielstone/materialaboutlibrary/ConvenienceBuilder.java
+++ b/library/src/main/java/com/danielstone/materialaboutlibrary/ConvenienceBuilder.java
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
@@ -29,8 +30,11 @@ public class ConvenienceBuilder {
     }
 
     public static MaterialAboutTitleItem createAppTitleItem(Context c) {
-        CharSequence appName = c.getPackageManager().getApplicationLabel(c.getApplicationInfo());
-        Drawable applicationIcon = c.getPackageManager().getApplicationIcon(c.getApplicationInfo());
+        Context applicationContext = c.getApplicationContext();
+        PackageManager packageManager = applicationContext.getPackageManager();
+        ApplicationInfo applicationInfo = applicationContext.getApplicationInfo();
+        CharSequence appName = packageManager.getApplicationLabel(applicationInfo);
+        Drawable applicationIcon = packageManager.getApplicationIcon(applicationInfo);
         return createAppTitleItem(appName == null ? "" : appName.toString(), applicationIcon);
     }
 


### PR DESCRIPTION
To avoid the activity leaking it is enough to pass the application context and not the activity directly to `ConvenienceBuilder`.

Fixes issue https://github.com/daniel-stoneuk/material-about-library/issues/74