### PR TITLE
Use MaterialCardView instead of CardView

### DIFF
--- a/library/src/main/res/layout/mal_material_about_list_card.xml
+++ b/library/src/main/res/layout/mal_material_about_list_card.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView
+<com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -53,4 +53,4 @@
 
     </LinearLayout>
 
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
You need to use `MaterialCardView` in order for the new style to be applied correctly.

There are a numerous amount of things which should be updated: if you don't mind, I can go ahead and create another PR.